### PR TITLE
fix: improve markdown parsing for italic text in webview

### DIFF
--- a/tasksync-chat/media/webview.js
+++ b/tasksync-chat/media/webview.js
@@ -1244,8 +1244,11 @@
         html = html.replace(/__([^_]+)__/g, '<strong>$1</strong>');
 
         // Italic (*text* or _text_)
+        // For *text*: standard markdown italic
         html = html.replace(/\*([^*]+)\*/g, '<em>$1</em>');
-        html = html.replace(/_([^_]+)_/g, '<em>$1</em>');
+        // For _text_: only match when surrounded by whitespace or string boundaries
+        // This prevents matching snake_case identifiers like xxx_yyy_zzz
+        html = html.replace(/(^|\s)_([^_\s][^_]*[^_\s])_(\s|$)/gm, '$1<em>$2</em>$3');
 
         // Line breaks - but collapse multiple consecutive breaks
         // Don't add <br> after block elements


### PR DESCRIPTION
Fixes an issue with incorrect display of text like `xxx_yyy_zzz`. Previously, it would turn into `xxxyyyzzz`, where `yyy` would be italicized.