### PR TITLE
feat: add cycling autopilot prompts array with drag-to-reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## TaskSync v2.0.24 (02-25-26)
+- feat: add cycling autopilot prompts array with drag-to-reorder
+- Multiple prompts cycle in order (1→2→3→1...) with each `ask_user` call
+- Add, edit, delete, and drag-to-reorder prompts in Settings modal
+- Backward compatible: existing `autopilotText` setting migrates automatically
+- Index resets on new session; preserved when toggling autopilot or manual response
+
 ## TaskSync v2.0.23 (02-24-26)
 - feat: implement context menu copy functionality and clipboard integration
-
 
 ## TaskSync v2.0.22 (02-21-26)
 - fix: simplify extension description for clarity

--- a/tasksync-chat/README.md
+++ b/tasksync-chat/README.md
@@ -17,11 +17,11 @@ Direct interaction with AI agents - respond to each request as it comes in with 
 
 ### Autopilot
 Let AI agents work autonomously by automatically responding to `ask_user` prompts. When enabled:
-- Agents receive a configurable auto-response instead of waiting for your input
+- Add multiple prompts that cycle in order (1→2→3→1...) with each `ask_user` call
+- Drag to reorder, edit, or delete individual prompts in the Settings modal
 - Toggle on/off from the Autopilot switch below the send button, or in Settings
-- Customize the Autopilot response text in Settings to control agent behavior
 - **Queue priority**: queued prompts are ALWAYS sent first — Autopilot only triggers when the queue is empty
-- Perfect for hands-free operation on well-defined tasks
+- Perfect for varying instructions mid-session or hands-free operation on well-defined tasks
 
 ### Response Timeout (Auto-respond when idle)
 Prevent tool calls from waiting indefinitely when you're away:
@@ -101,10 +101,11 @@ Paste or drag-and-drop images directly into the chat input. Images are automatic
 
 ### Autopilot Mode
 1. Enable **Autopilot** from the toggle below the send button, or in Settings
-2. When an AI agent calls `ask_user`, TaskSync automatically responds with your configured Autopilot text
-3. Customize the response text in Settings (gear icon) → Autopilot
-4. **Queue priority**: queued prompts are always sent first — Autopilot only triggers when the queue is empty
-5. Toggle off anytime to return to manual interaction
+2. When an AI agent calls `ask_user`, TaskSync automatically responds with the next prompt in your cycling list
+3. Add multiple prompts in Settings (gear icon) → Autopilot Prompts — they cycle 1→2→3→1...
+4. Drag to reorder, click to edit, or delete individual prompts
+5. **Queue priority**: queued prompts are always sent first — Autopilot only triggers when the queue is empty
+6. Toggle off anytime to return to manual interaction
 
 ### File References
 1. Type `#` in the input field

--- a/tasksync-chat/media/main.css
+++ b/tasksync-chat/media/main.css
@@ -2321,7 +2321,100 @@ button#send-btn:disabled {
     display: none;
 }
 
+/* ========== Autopilot Prompts List ========== */
+.autopilot-prompts-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 6px;
+    min-height: 24px;
+}
 
+.empty-prompts-hint {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    padding: 8px;
+    text-align: center;
+    font-style: italic;
+}
+
+.autopilot-prompt-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    background-color: var(--vscode-input-background);
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 4px;
+    transition: border-color 0.15s ease, transform 0.15s ease, opacity 0.15s ease;
+    cursor: grab;
+}
+
+.autopilot-prompt-item:hover {
+    border-color: var(--vscode-focusBorder);
+}
+
+.autopilot-prompt-item.dragging {
+    opacity: 0.5;
+    cursor: grabbing;
+}
+
+.autopilot-prompt-item.drag-over-top {
+    border-top: 2px solid var(--vscode-focusBorder);
+}
+
+.autopilot-prompt-item.drag-over-bottom {
+    border-bottom: 2px solid var(--vscode-focusBorder);
+}
+
+.autopilot-prompt-drag-handle {
+    color: var(--vscode-descriptionForeground);
+    cursor: grab;
+    flex-shrink: 0;
+}
+
+.autopilot-prompt-number {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--vscode-descriptionForeground);
+    flex-shrink: 0;
+    margin-right: -2px;
+}
+
+.autopilot-prompt-text {
+    font-size: 12px;
+    color: var(--vscode-foreground);
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.autopilot-prompt-actions {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.autopilot-prompt-item:hover .autopilot-prompt-actions {
+    opacity: 1;
+}
+
+/* Add Autopilot Prompt Form */
+.add-autopilot-prompt-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 8px;
+    padding: 10px;
+    background-color: var(--vscode-input-background);
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 4px;
+}
+
+/* ========== End Autopilot Prompts List ========== */
 
 /* Add Prompt Form */
 .add-prompt-form {

--- a/tasksync-chat/package.json
+++ b/tasksync-chat/package.json
@@ -4,7 +4,7 @@
   "displayName": "TaskSync",
   "description": "Queue your prompts or tasks. Work uninterrupted.",
   "icon": "media/Tasksync-logo.png",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "engines": {
     "vscode": "^1.90.0"
   },
@@ -113,6 +113,15 @@
           "default": "You are temporarily in autonomous mode and must now make your own decision. If another question arises, be sure to ask it, as autonomous mode is temporary.",
           "scope": "window",
           "description": "Text returned when Autopilot is enabled. The agent receives this as an automatic response."
+        },
+        "tasksync.autopilotPrompts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "scope": "window",
+          "description": "Array of prompts that cycle in order during Autopilot (1→2→3→1...). Each prompt is sent sequentially with human-like delay. When empty, falls back to autopilotText."
         },
         "tasksync.responseTimeout": {
           "type": "string",


### PR DESCRIPTION
## Summary
Transform the single autopilot prompt into a cycling array of prompts that fire in sequence (1→2→3→1...).

## Changes  
- **Backend**: Cycling logic with `_autopilotPrompts: string[]` and `_autopilotIndex`
- **Settings**: New `tasksync.autopilotPrompts` configuration (array of strings)
- **UI**: Prompts list in Settings modal with add/edit/delete and drag-to-reorder
- **Migration**: Existing `autopilotText` users work without changes

## Features
- Multiple prompts cycle in order with each `ask_user` call
- Drag-to-reorder with visual feedback
- Index resets on new session
- Human-like delay applies to all prompts
- Queue priority preserved (queue > autopilot)

## Files Changed
- `webviewProvider.ts` - cycling logic, CRUD handlers
- `package.json` - settings schema, version 2.0.23
- `webview.js` - UI rendering, drag-drop
- `main.css` - prompts list styles
- `README.md` - updated documentation
- `CHANGELOG.md` - v2.0.23 entry