### PR TITLE
feat: add multi-select support for interactive choice buttons

### DIFF
--- a/tasksync-chat/media/main.css
+++ b/tasksync-chat/media/main.css
@@ -1840,6 +1840,7 @@ button#send-btn:disabled {
     gap: 6px;
     flex-wrap: wrap;
     justify-content: flex-end;
+    flex: 1;
 }
 
 /* Choice button - compact numbered style */
@@ -1870,6 +1871,74 @@ button#send-btn:disabled {
 
 .choice-btn:active {
     transform: scale(0.98);
+}
+
+/* Selected choice button */
+.choice-btn.selected {
+    background-color: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border-color: var(--vscode-button-background);
+}
+
+.choice-btn.selected:hover {
+    background-color: var(--vscode-button-hoverBackground);
+    border-color: var(--vscode-button-hoverBackground);
+}
+
+/* Actions container for All/Send buttons */
+.choices-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+/* Action buttons (All, Send) */
+.choices-action-btn {
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    font-family: var(--vscode-font-family);
+    border: 1px solid var(--vscode-panel-border);
+    background: transparent;
+    color: var(--vscode-foreground);
+    white-space: nowrap;
+}
+
+.choices-action-btn:hover {
+    background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.choices-action-btn:focus {
+    outline: 2px solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+}
+
+.choices-action-btn:active {
+    transform: scale(0.98);
+}
+
+.choices-action-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.choices-action-btn:disabled:hover {
+    background: transparent;
+}
+
+/* Send button - primary style when enabled */
+.choices-send-btn:not(:disabled) {
+    background-color: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border-color: var(--vscode-button-background);
+}
+
+.choices-send-btn:not(:disabled):hover {
+    background-color: var(--vscode-button-hoverBackground);
 }
 
 /* ===== SLASH COMMAND DROPDOWN STYLES ===== */

--- a/tasksync-chat/media/webview.js
+++ b/tasksync-chat/media/webview.js
@@ -953,7 +953,18 @@
 
     function handleSend() {
         var text = chatInput ? chatInput.value.trim() : '';
-        if (!text && currentAttachments.length === 0) return;
+        if (!text && currentAttachments.length === 0) {
+            // If choices are selected and input is empty, send the selected choices
+            var choicesBar = document.getElementById('choices-bar');
+            if (choicesBar && !choicesBar.classList.contains('hidden')) {
+                var selectedButtons = choicesBar.querySelectorAll('.choice-btn.selected');
+                if (selectedButtons.length > 0) {
+                    handleChoicesSend();
+                    return;
+                }
+            }
+            return;
+        }
 
         // Expand slash commands to full prompt text
         text = expandSlashCommands(text);
@@ -2037,7 +2048,7 @@
     }
 
     /**
-     * Show choices bar with dynamic buttons based on parsed choices
+     * Show choices bar with toggleable multi-select buttons
      */
     function showChoicesBar() {
         // Hide approval modal first
@@ -2059,30 +2070,45 @@
             }
         }
 
-        // Build choice buttons
-        var buttonsHtml = currentChoices.map(function (choice, index) {
+        // Build toggleable choice buttons
+        var buttonsHtml = currentChoices.map(function (choice) {
             var shortLabel = choice.shortLabel || choice.value;
             var title = choice.label || choice.value;
             return '<button class="choice-btn" data-value="' + escapeHtml(choice.value) + '" ' +
-                'data-index="' + index + '" title="' + escapeHtml(title) + '">' +
+                'title="' + escapeHtml(title) + '" ' +
+                'aria-pressed="false">' +
                 escapeHtml(shortLabel) + '</button>';
         }).join('');
 
         choicesBar.innerHTML = '<span class="choices-label">Choose:</span>' +
-            '<div class="choices-buttons">' + buttonsHtml + '</div>';
+            '<div class="choices-buttons">' + buttonsHtml + '</div>' +
+            '<div class="choices-actions">' +
+            '<button class="choices-action-btn choices-all-btn" title="Select all" aria-label="Select all">All</button>' +
+            '<button class="choices-action-btn choices-send-btn" title="Send selected" aria-label="Send selected choices" disabled>Send</button>' +
+            '</div>';
 
-        // Bind click events to choice buttons
+        // Bind click events to choice buttons (toggle selection)
         choicesBar.querySelectorAll('.choice-btn').forEach(function (btn) {
             btn.addEventListener('click', function () {
-                var value = btn.getAttribute('data-value');
-                handleChoiceClick(value);
+                handleChoiceToggle(btn);
             });
         });
 
+        // Bind 'All' button
+        var allBtn = choicesBar.querySelector('.choices-all-btn');
+        if (allBtn) {
+            allBtn.addEventListener('click', handleChoicesSelectAll);
+        }
+
+        // Bind 'Send' button
+        var choicesSendBtn = choicesBar.querySelector('.choices-send-btn');
+        if (choicesSendBtn) {
+            choicesSendBtn.addEventListener('click', handleChoicesSend);
+        }
+
         choicesBar.classList.remove('hidden');
 
-        // Don't auto-focus buttons - let user click or use keyboard
-        // Focus the chat input instead for immediate typing
+        // Focus chat input for immediate typing
         if (chatInput) {
             chatInput.focus();
         }
@@ -2100,16 +2126,66 @@
     }
 
     /**
-     * Handle choice button click
+     * Toggle a choice button's selected state
      */
-    function handleChoiceClick(value) {
+    function handleChoiceToggle(btn) {
         if (!pendingToolCall) return;
+
+        var isSelected = btn.classList.toggle('selected');
+        btn.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+
+        updateChoicesSendButton();
+    }
+
+    /**
+     * Toggle all choices selected/deselected
+     */
+    function handleChoicesSelectAll() {
+        if (!pendingToolCall) return;
+
+        var choicesBar = document.getElementById('choices-bar');
+        if (!choicesBar) return;
+
+        var buttons = choicesBar.querySelectorAll('.choice-btn');
+        var allSelected = Array.from(buttons).every(function (btn) {
+            return btn.classList.contains('selected');
+        });
+
+        buttons.forEach(function (btn) {
+            if (allSelected) {
+                btn.classList.remove('selected');
+                btn.setAttribute('aria-pressed', 'false');
+            } else {
+                btn.classList.add('selected');
+                btn.setAttribute('aria-pressed', 'true');
+            }
+        });
+
+        updateChoicesSendButton();
+    }
+
+    /**
+     * Send all selected choices as a comma-separated response
+     */
+    function handleChoicesSend() {
+        if (!pendingToolCall) return;
+
+        var choicesBar = document.getElementById('choices-bar');
+        if (!choicesBar) return;
+
+        var selectedButtons = choicesBar.querySelectorAll('.choice-btn.selected');
+        if (selectedButtons.length === 0) return;
+
+        var values = Array.from(selectedButtons).map(function (btn) {
+            return btn.getAttribute('data-value');
+        });
+        var responseValue = values.join(', ');
 
         // Hide choices bar
         hideChoicesBar();
 
-        // Send the choice value as response
-        vscode.postMessage({ type: 'submit', value: value, attachments: [] });
+        // Send the response
+        vscode.postMessage({ type: 'submit', value: responseValue, attachments: [] });
         if (chatInput) {
             chatInput.value = '';
             chatInput.style.height = 'auto';
@@ -2119,6 +2195,32 @@
         updateChipsDisplay();
         updateSendButtonState();
         saveWebviewState();
+    }
+
+    /**
+     * Update the Send button state and All button label based on current selections
+     */
+    function updateChoicesSendButton() {
+        var choicesBar = document.getElementById('choices-bar');
+        if (!choicesBar) return;
+
+        var selectedCount = choicesBar.querySelectorAll('.choice-btn.selected').length;
+        var totalCount = choicesBar.querySelectorAll('.choice-btn').length;
+        var choicesSendBtn = choicesBar.querySelector('.choices-send-btn');
+        var allBtn = choicesBar.querySelector('.choices-all-btn');
+
+        if (choicesSendBtn) {
+            choicesSendBtn.disabled = selectedCount === 0;
+            choicesSendBtn.textContent = selectedCount > 0 ? 'Send (' + selectedCount + ')' : 'Send';
+        }
+
+        if (allBtn) {
+            var isAllSelected = totalCount > 0 && selectedCount === totalCount;
+            allBtn.textContent = isAllSelected ? 'None' : 'All';
+            var allBtnActionLabel = isAllSelected ? 'Deselect all' : 'Select all';
+            allBtn.title = allBtnActionLabel;
+            allBtn.setAttribute('aria-label', allBtnActionLabel);
+        }
     }
 
     // ===== SETTINGS MODAL FUNCTIONS =====


### PR DESCRIPTION
## Problem

When an AI agent presents numbered options (e.g., "1. Fix tests, 2. Add logging, 3. Refactor utils"), TaskSync shows clickable buttons in the choices bar. Clicking any button immediately sends that single value as the response.

This means there's no way to select multiple options at once. If you want to say "do 1, 3, and 4", you have to dismiss the buttons and manually type it in the text input. There's also no quick way to select all of them.

## Solution

Choice buttons are now toggleable with multi-select support:

- **Click to toggle** - each button switches between selected and unselected. Selected buttons are highlighted using VS Code theme button colors.
- **"All" button** - selects or deselects every choice. Toggles its label between "All" and "None" to reflect the current state.
- **"Send" button** - sends selected choices as a comma-separated response (e.g., `1, 3, 4`). Shows the count while active (`Send (3)`) and stays disabled until at least one choice is selected.
- **Enter key** - pressing Enter with an empty input but selected choices sends the selections automatically.
- Users can still type a custom response in the text input at any time, which takes priority over button selections.

## Why this change matters

Multi-select is a common need when AI agents present option lists. Users frequently want to pick a subset or all choices, not just one. This change makes that workflow quick and intuitive instead of requiring manual typing.

The implementation is purely frontend (no backend changes). The response value is just a comma-separated string, so it works with any AI agent that already understands numbered options. All styling uses VS Code theme variables, adapting correctly to any color theme. Toggle buttons include proper `aria-pressed` attributes for accessibility.

## Changes

| File | What changed |
|------|-------------|
| `tasksync-chat/media/webview.js` | Replaced single-click `handleChoiceClick()` with toggle-based selection: `handleChoiceToggle()`, `handleChoicesSelectAll()`, `handleChoicesSend()`, `updateChoicesSendButton()`. Updated `handleSend()` to support Enter-to-send with selected choices. |
| `tasksync-chat/media/main.css` | Added `.choice-btn.selected` highlight styles, `.choices-actions` container, `.choices-action-btn` base styles, `.choices-send-btn` primary styling. Added `flex: 1` to `.choices-buttons` for proper layout with action buttons. |