### PR TITLE
fix: remote mode mobile zoom on input focus + Safari WebSocket error guidance

### DIFF
--- a/tasksync-chat/media/remote-fallback.css
+++ b/tasksync-chat/media/remote-fallback.css
@@ -9,7 +9,7 @@
     --vscode-foreground: #cccccc;
     --vscode-focusBorder: #007fd4;
     --vscode-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    --vscode-font-size: 13px;
+    --vscode-font-size: 16px;
     --vscode-font-weight: 400;
 
     /* Sidebar / Background */
@@ -249,4 +249,11 @@ body.remote-mode {
     font-family: system-ui;
     color: #ccc;
     background: #1e1e1e;
+}
+
+/* SSOT: Prevent auto-zoom on input focus (triggered when font-size < 16px) */
+body.remote-mode input,
+body.remote-mode textarea,
+body.remote-mode select {
+    font-size: max(var(--vscode-font-size), 16px) !important;
 }

--- a/tasksync-chat/media/webview.js
+++ b/tasksync-chat/media/webview.js
@@ -49,6 +49,11 @@ const isRemoteMode = typeof acquireVsCodeApi === "undefined";
 // Debug mode: enable via localStorage.setItem('TASKSYNC_DEBUG', 'true')
 const REMOTE_DEBUG =
 	isRemoteMode && localStorage.getItem("TASKSYNC_DEBUG") === "true";
+/** Detect Safari (excludes Chrome/Chromium-based and iOS alternative browsers). */
+const isRemoteSafari =
+	isRemoteMode &&
+	/Safari/.test(navigator.userAgent) &&
+	!/(Chrome|Chromium|CriOS|FxiOS|EdgiOS|OPiOS)/.test(navigator.userAgent);
 function debugLog(...args) {
 	if (REMOTE_DEBUG) console.log("[TaskSync Debug]", ...args);
 }
@@ -287,7 +292,9 @@ function updateRemoteConnectionStatus(status, reason) {
 		} else if (reason === "shutdown") {
 			indicator.title = "Server stopped";
 		} else if (reason === "max-attempts") {
-			indicator.title = "Connection failed - server unreachable";
+			indicator.title = isRemoteSafari
+				? "Connection failed \u2014 Safari may block WebSocket when Private Relay is on. Disable it in Settings \u2192 Safari \u2192 Privacy, or use Chrome."
+				: "Connection failed - server unreachable";
 		} else {
 			indicator.title = "Disconnected - reconnecting...";
 		}

--- a/tasksync-chat/src/webview-ui/adapter.js
+++ b/tasksync-chat/src/webview-ui/adapter.js
@@ -4,6 +4,11 @@ const isRemoteMode = typeof acquireVsCodeApi === "undefined";
 // Debug mode: enable via localStorage.setItem('TASKSYNC_DEBUG', 'true')
 const REMOTE_DEBUG =
 	isRemoteMode && localStorage.getItem("TASKSYNC_DEBUG") === "true";
+/** Detect Safari (excludes Chrome/Chromium-based and iOS alternative browsers). */
+const isRemoteSafari =
+	isRemoteMode &&
+	/Safari/.test(navigator.userAgent) &&
+	!/(Chrome|Chromium|CriOS|FxiOS|EdgiOS|OPiOS)/.test(navigator.userAgent);
 function debugLog(...args) {
 	if (REMOTE_DEBUG) console.log("[TaskSync Debug]", ...args);
 }
@@ -242,7 +247,9 @@ function updateRemoteConnectionStatus(status, reason) {
 		} else if (reason === "shutdown") {
 			indicator.title = "Server stopped";
 		} else if (reason === "max-attempts") {
-			indicator.title = "Connection failed - server unreachable";
+			indicator.title = isRemoteSafari
+				? "Connection failed \u2014 Safari may block WebSocket when Private Relay is on. Disable it in Settings \u2192 Safari \u2192 Privacy, or use Chrome."
+				: "Connection failed - server unreachable";
 		} else {
 			indicator.title = "Disconnected - reconnecting...";
 		}

--- a/tasksync-chat/web/login.js
+++ b/tasksync-chat/web/login.js
@@ -5,6 +5,11 @@ const LOGIN_CONNECT_TIMEOUT_MS = 10000; // WebSocket connection timeout
 const SESSION_KEYS = TASKSYNC_SESSION_KEYS; // Reference shared SSOT constant
 const getWsProtocol = getTaskSyncWsProtocol; // Reference shared SSOT helper
 
+/** Detect Safari (excludes Chrome/Chromium-based and iOS alternative browsers). */
+const isSafari =
+	/Safari/.test(navigator.userAgent) &&
+	!/(Chrome|Chromium|CriOS|FxiOS|EdgiOS|OPiOS)/.test(navigator.userAgent);
+
 // Register service worker for PWA support (caching, offline, install)
 if ("serviceWorker" in navigator) {
     navigator.serviceWorker
@@ -163,7 +168,11 @@ function attemptConnect() {
                 ws.close();
             } catch { }
             setConnecting(false);
-            setError("Connection timed out");
+            if (isSafari) {
+                setError("Connection timed out \u2014 Safari may block WebSocket when iCloud Private Relay is on. Try disabling it in Settings \u2192 Safari \u2192 Privacy (\u201cHide IP Address\u201d \u2192 \u201cTrackers Only\u201d), or use Chrome instead.");
+            } else {
+                setError("Connection timed out");
+            }
         }
     }, LOGIN_CONNECT_TIMEOUT_MS);
 
@@ -210,7 +219,11 @@ function attemptConnect() {
     ws.onerror = () => {
         clearTimeout(connectTimeout);
         setConnecting(false);
-        setError("Connection failed");
+        if (isSafari) {
+            setError("Connection failed \u2014 Safari may block WebSocket when iCloud Private Relay is on. Try disabling it in Settings \u2192 Safari \u2192 Privacy (\u201cHide IP Address\u201d \u2192 \u201cTrackers Only\u201d), or use Chrome instead.");
+        } else {
+            setError("Connection failed");
+        }
     };
 
     ws.onclose = () => {


### PR DESCRIPTION
## Issues

### 1. Mobile auto-zoom on input focus (all browsers)
When tapping input fields in remote mode on mobile devices, the browser zooms in automatically. This makes the UI unusable — the viewport shifts, the user has to pinch-zoom back out, and the layout is no longer constrained to the screen.

**Root cause:** Mobile browsers (iOS Safari, Chrome, Android) auto-zoom when an input field's computed `font-size` is below 16px. The remote mode fallback CSS set `--vscode-font-size: 13px`, which was inherited by all form elements.

### 2. Safari/iOS 26 WebSocket connection failure (no guidance)
Users on Safari (iOS 26+) with iCloud Private Relay enabled get a generic "Connection failed" error when trying to connect to the TaskSync remote server. No explanation is given about why it fails or how to fix it.

**Root cause:** Safari/iOS 26 sends `CONNECT` proxy requests instead of proper HTTP upgrade requests for WebSocket connections when iCloud Private Relay is enabled. The server rejects this malformed request. Setting "Hide IP Address" to "Trackers Only" (instead of "All Browsing") resolves it.

**References:**
- [WebKit Bug #302561](https://bugs.webkit.org/show_bug.cgi?id=302561) — Safari on iOS 26.1 with iCloud Privacy Relay: WebSocket failures with detailed reproduction steps
- [Jack Pearce: macOS 26/iOS 26 Safari WebSocket Upgrade Failures](https://www.jackpearce.co.uk/posts/debugging-websocket-upgrade-failures-safari-ios26/) — Deep technical analysis showing CONNECT vs GET request bug
- [Apple Developer Forums](https://developer.apple.com/forums/thread/819173) — Developer reports of connectivity issues with Private Relay on iOS 26
- [Apple Support Community](https://discussions.apple.com/thread/256142477) — Users reporting WebSocket failures across multiple services (Home Assistant, Unraid, Proxmox, GCP)
- [Reddit r/webdev](https://www.reddit.com/r/webdev/comments/1pzmhvf/websocket_broken_on_safariios_26/) — WebSocket broken on Safari/iOS 26 discussion

---

## Solutions

### Fix 1: Mobile zoom prevention (CSS SSOT)

Added an SSOT rule in `remote-fallback.css` that enforces a 16px minimum on all form elements in remote mode:
```css
body.remote-mode input,
body.remote-mode textarea,
body.remote-mode select {
    font-size: max(var(--vscode-font-size), 16px) !important;
}
```
Also updated the `--vscode-font-size` fallback from `13px` to `16px`.

This prevents auto-zoom while preserving pinch-zoom accessibility (no `maximum-scale` restriction).

### Fix 2: Safari WebSocket error guidance

Added Safari user-agent detection in two files, excluding iOS alternative browsers (`CriOS`, `FxiOS`, `EdgiOS`, `OPiOS`):

**`web/login.js`** (login page):
- On `ws.onerror` and connection timeout: shows a Safari-specific error message explaining the Private Relay issue and how to fix it (Settings → Safari → Privacy → set "Hide IP Address" to "Trackers Only"), or suggests using Chrome instead

**`src/webview-ui/adapter.js`** (remote app reconnection):
- When max reconnection attempts are exhausted, the tooltip shows the Private Relay fix or Chrome suggestion instead of the generic "Connection lost"

---

## Files changed

| File | Change |
|------|--------|
| `media/remote-fallback.css` | `--vscode-font-size: 16px` (was 13px), added `body.remote-mode` scoped form element rule with `!important` |
| `web/login.js` | Robust Safari detection + Safari-specific WebSocket error messages (double quotes) |
| `src/webview-ui/adapter.js` | Robust Safari detection + Safari-specific reconnection tooltip |
| `media/webview.js` | Rebuilt webview bundle |

## Testing

- 436 tests pass (21 test files)
- Build, type-check, lint, code quality scanner all pass
- Manually verified on iPhone (iOS 26): zoom no longer triggers on input focus
- Manually verified Safari error messages appear correctly