### PR TITLE
fix: detect visual lines for ArrowUp/ArrowDown history recall

### DIFF
--- a/tasksync-chat/media/webview.js
+++ b/tasksync-chat/media/webview.js
@@ -2395,7 +2395,6 @@ function createTextareaMirror() {
 	mirror.style.visibility = "hidden";
 	mirror.style.height = "auto";
 	mirror.style.whiteSpace = cs.whiteSpace;
-	mirror.style.wordWrap = cs.wordWrap;
 	mirror.style.overflowWrap = cs.overflowWrap;
 	mirror.style.wordBreak = cs.wordBreak;
 	mirror.style.width = chatInput.clientWidth + "px";

--- a/tasksync-chat/src/webview-ui/input.js
+++ b/tasksync-chat/src/webview-ui/input.js
@@ -50,7 +50,6 @@ function createTextareaMirror() {
 	mirror.style.visibility = "hidden";
 	mirror.style.height = "auto";
 	mirror.style.whiteSpace = cs.whiteSpace;
-	mirror.style.wordWrap = cs.wordWrap;
 	mirror.style.overflowWrap = cs.overflowWrap;
 	mirror.style.wordBreak = cs.wordBreak;
 	mirror.style.width = chatInput.clientWidth + "px";


### PR DESCRIPTION
## Problem

PR #71 introduced ArrowUp/ArrowDown history recall, but `isCursorOnFirstLine()` and `isCursorOnLastLine()` only checked for `\n` characters (logical lines). Long single-line text that wraps visually would immediately trigger history recall instead of letting the cursor navigate through visual lines first.

Fixes #75

## Root Cause

```javascript
// Only checks for \n — ignores word-wrapped visual lines
function isCursorOnFirstLine() {
    return text.lastIndexOf("\n", pos - 1) === -1;
}
```

A textarea with `word-wrap: break-word` renders long text across multiple visual lines without `\n`. Both functions returned `true` for any single-line text regardless of wrapping, making keyboard navigation impossible.

## Solution

Replace both functions with `areSameVisualLine(posA, posB)` — renders the full text in a hidden mirror `<div>` (matching the textarea's font, width, padding, word-wrap) with zero-width probes at two positions, then compares their `offsetTop` values.

- `isCursorOnFirstVisualLine()` → `areSameVisualLine(0, selectionStart)`
- `isCursorOnLastVisualLine()` → `areSameVisualLine(selectionEnd, text.length)`

Using `offsetTop` equality (instead of height-difference thresholds) avoids pixel-rounding issues.

## Files Changed

| File | Change |
|------|--------|
| `src/webview-ui/input.js` | Replace `isCursorOnFirstLine`/`isCursorOnLastLine` with `areSameVisualLine()` + visual-line-aware wrappers |
| `media/webview.js` | Rebuilt bundle |

## Validation

- Build: ✅
- TypeScript (`tsc --noEmit`): ✅ 0 errors
- Tests (`vitest run`): ✅ 441 tests passing
- Lint (`biome check`): ✅ 0 issues
- Code quality (`check-code`): ✅ All checks pass